### PR TITLE
Rails version pin, spec_helper fixes

### DIFF
--- a/newspaper_works.gemspec
+++ b/newspaper_works.gemspec
@@ -26,7 +26,7 @@ SUMMARY
   spec.add_dependency 'blacklight_advanced_search', '6.4.1'
   spec.add_dependency 'hyrax', '>= 2.5.1', '~> 2'
   spec.add_dependency 'nokogiri'
-  spec.add_dependency 'rails', '~> 5.1'
+  spec.add_dependency 'rails', '~> 5.1.0'
   spec.add_dependency 'sass-rails', '~> 5.0'
 
   spec.add_development_dependency 'bixby'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,15 @@ require 'rspec/active_model/mocks'
 require 'selenium-webdriver'
 require 'webdrivers'
 
+# monkey patch Hyrax::VirusScanner#null_scanner to be quiet:
+module Hyrax
+  class VirusScanner
+    def null_scanner
+      false # no warning output, just correct return value
+    end
+  end
+end
+
 # @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
 #       container build environments to mitigate Meltdown/Spectre
 #       vulnerabilities, at which point Hyrax could no longer use the
@@ -115,8 +124,12 @@ RSpec.configure do |config|
 
   config.include EngineRoutes, type: :controller
 
-  # ensure Hyrax has active sipity workflow for default admin set:
+  # start with clean repository, active sipity workflow for default admin set:
   config.before(:suite) do
+    # completely clean repository before suite:
+    require 'active_fedora/cleaner'
+    ActiveFedora::Cleaner.clean!
+
     begin
       # ensure permission template actually exists in RDBMS:
       id = 'admin_set/default'


### PR DESCRIPTION
This PR has two unrelated minor changes:

1. Pin rails version to 5.1.x, not 5.x.
2. Cherry-pick from `hyrax-3` branch a modification to `spec/spec_helper.rb` that invokes `ActiveFedora::Cleaner.clean!` (once) before suite execution.  _This helps in certain cases with dirty repository state, which can aide corner-cases where local testing breaks_.

_Note: included in the spec_helper.rb changes, there is an incidental and totally harmless monkey-patch for a Hyrax 3 patch — it will not have any side-effects in Hyrax 2, and cherry-picking that commit can help avoid future merge conflicts._