### PR TITLE
Article Ingest work-in-progress [Partially complete, see notes below] 

### DIFF
--- a/lib/newspaper_works/ingest.rb
+++ b/lib/newspaper_works/ingest.rb
@@ -22,6 +22,7 @@ require 'newspaper_works/ingest/base_ingest'
 require 'newspaper_works/ingest/ndnp'
 require 'newspaper_works/ingest/newspaper_page_ingest'
 require 'newspaper_works/ingest/newspaper_issue_ingest'
+require 'newspaper_works/ingest/uu_article_segmented'
 
 module NewspaperWorks
   # Module for Ingest adapters that import files into model objects

--- a/lib/newspaper_works/ingest/batch_ingest_helper.rb
+++ b/lib/newspaper_works/ingest/batch_ingest_helper.rb
@@ -1,4 +1,6 @@
 require 'find'
+require 'open3'
+require 'tmpdir'
 
 module NewspaperWorks
   module Ingest

--- a/lib/newspaper_works/ingest/batch_ingest_helper.rb
+++ b/lib/newspaper_works/ingest/batch_ingest_helper.rb
@@ -3,6 +3,9 @@ require 'find'
 module NewspaperWorks
   module Ingest
     # mixin module for common batch ingest steps
+    #
+    # Presumed contract for consuming class:
+    # - Has accessors for path, lccn, publication, opts
     module BatchIngestHelper
       def detect_media(path)
         result = 'pdf' # default
@@ -38,6 +41,79 @@ module NewspaperWorks
         attachment = NewspaperWorks::Data::WorkFiles.of(work)
         attachment.assign(path)
         attachment.commit!
+      end
+
+      def link_publication(issue)
+        find_or_create_publication_for_issue(
+          issue,
+          lccn,
+          publication.title,
+          opts
+        )
+      end
+
+      def create_issue(issue_data)
+        issue = NewspaperIssue.create
+        copy_issue_metadata(issue_data, issue)
+        NewspaperWorks::Ingest.assign_administrative_metadata(issue, opts)
+        issue.save!
+        write_log(
+          "Created new NewspaperIssue work with date, lccn, edition metadata:"\
+          "\n"\
+          "\tLCCN: #{lccn}\n"\
+          "\tPublication Date: #{issue_data.publication_date}\n"\
+          "\tEdition number: #{issue_data.edition_number}"
+        )
+        link_publication(issue)
+        issue
+      end
+
+      def ingest_pdf(issue, path)
+        # ingest primary PDF for issue:
+        attach_file(issue, path)
+        # queue page creation job:
+        CreateIssuePagesJob.perform_later(issue, [path], nil, nil)
+      end
+
+      def create_page(page_image, issue)
+        page = NewspaperPage.create
+        page.title = page_image.title
+        page.page_number = page_image.page_number
+        page.save!
+        # Link page as a child of issue, via ordered members:
+        issue.ordered_members << page
+        NewspaperWorks::Ingest.assign_administrative_metadata(page, opts)
+        issue.save!
+        # Ensure we have a source TIFF file, attach to page:
+        path = page_image.path
+        path = page_image.path.end_with?('jp2') ? make_tiff(path) : path
+        attach_file(page, path)
+      end
+
+      def ingest_pages(issue, issue_data)
+        # Create pages in order they appear (lexical)
+        issue_data.each_value { |page_image| create_page(page_image, issue) }
+        # Make an issue PDF from constituent pages, via retryable async job,
+        #   which will not succeed until the PDF derivatives are created
+        #   for each page, but should eventually succeed on that condition:
+        NewspaperWorks::ComposeIssuePDFJob.perform_later(issue)
+      end
+
+      def make_tiff(path)
+        raise ArgumentError unless path.end_with?('jp2')
+        Hyrax.config.whitelisted_ingest_dirs |= [Dir.tmpdir]
+        name = File.basename(path).split('.')[0]
+        # OpenJPEG2000 has weird quirk, only likes 3-char file ext TIF:
+        tiff_path = File.join(Dir.mktmpdir, "#{name}.tif")
+        cmd = "opj_decompress -i #{path} -o #{tiff_path}"
+        Open3.popen3(cmd) do |_stdin, _stdout, stderr, _wait_thr|
+          unless stderr.read.strip.empty?
+            msg = "Error converting JP2 to TIFF: #{path}"
+            write_log(msg, Logger::ERROR)
+            raise msg
+          end
+        end
+        tiff_path
       end
     end
   end

--- a/lib/newspaper_works/ingest/batch_issue_ingester.rb
+++ b/lib/newspaper_works/ingest/batch_issue_ingester.rb
@@ -32,87 +32,14 @@ module NewspaperWorks
         impl.new(path, publication)
       end
 
-      def link_publication(issue)
-        find_or_create_publication_for_issue(
-          issue,
-          @lccn,
-          @publication.title,
-          @opts
-        )
-      end
-
-      def create_issue(issue_data)
-        issue = NewspaperIssue.create
-        copy_issue_metadata(issue_data, issue)
-        NewspaperWorks::Ingest.assign_administrative_metadata(issue, @opts)
-        issue.save!
-        write_log(
-          "Created new NewspaperIssue work with date, lccn, edition metadata:"\
-          "\n"\
-          "\tLCCN: #{@lccn}\n"\
-          "\tPublication Date: #{issue_data.publication_date}\n"\
-          "\tEdition number: #{issue_data.edition_number}"
-        )
-        link_publication(issue)
-        issue
-      end
-
-      def ingest_pdf(issue, path)
-        # ingest primary PDF for issue:
-        attach_file(issue, path)
-        # queue page creation job:
-        CreateIssuePagesJob.perform_later(issue, [path], nil, nil)
-      end
-
-      def create_page(page_image, issue)
-        page = NewspaperPage.create
-        page.title = page_image.title
-        page.page_number = page_image.page_number
-        page.save!
-        # Link page as a child of issue, via ordered members:
-        issue.ordered_members << page
-        NewspaperWorks::Ingest.assign_administrative_metadata(page, @opts)
-        issue.save!
-        # Ensure we have a source TIFF file, attach to page:
-        path = page_image.path
-        path = page_image.path.end_with?('jp2') ? make_tiff(path) : path
-        attach_file(page, path)
-      end
-
-      def ingest_pages(issue, issue_data)
-        # Create pages in order they appear (lexical)
-        issue_data.each_value { |page_image| create_page(page_image, issue) }
-        # Make an issue PDF from constituent pages, via retryable async job,
-        #   which will not succeed until the PDF derivatives are created
-        #   for each page, but should eventually succeed on that condition:
-        NewspaperWorks::ComposeIssuePDFJob.perform_later(issue)
-      end
-
-      def make_tiff(path)
-        raise ArgumentError unless path.end_with?('jp2')
-        Hyrax.config.whitelisted_ingest_dirs |= [Dir.tmpdir]
-        name = File.basename(path).split('.')[0]
-        # OpenJPEG2000 has weird quirk, only likes 3-char file ext TIF:
-        tiff_path = File.join(Dir.mktmpdir, "#{name}.tif")
-        cmd = "opj_decompress -i #{path} -o #{tiff_path}"
-        Open3.popen3(cmd) do |_stdin, _stdout, stderr, _wait_thr|
-          unless stderr.read.strip.empty?
-            msg = "Error converting JP2 to TIFF: #{path}"
-            write_log(msg, Logger::ERROR)
-            raise msg
-          end
-        end
-        tiff_path
-      end
-
       def ingest_type
         return 'issue_pdf' if @issues.class == NewspaperWorks::Ingest::PDFIssues
         'page_image'
       end
 
       def ingest
-        write_log("Beginning issue(s) batch ingest for #{@path}")
-        write_log("\tPublication: #{@publication.title} (LCCN: #{@lccn})")
+        write_log("Beginning issue(s) batch ingest for #{path}")
+        write_log("\tPublication: #{publication.title} (LCCN: #{lccn})")
         @issues.each do |path, issue_data|
           issue = create_issue(issue_data)
           tactic = ingest_type
@@ -120,7 +47,7 @@ module NewspaperWorks
           ingest_pages(issue, issue_data) if tactic == 'page_image'
         end
         write_log(
-          "Issue ingest completed for LCCN #{@lccn}. Asyncrhonous jobs "\
+          "Issue ingest completed for LCCN #{lccn}. Asyncrhonous jobs "\
           "may still be creating derivatives for issue, and child page works."
         )
       end

--- a/lib/newspaper_works/ingest/batch_issue_ingester.rb
+++ b/lib/newspaper_works/ingest/batch_issue_ingester.rb
@@ -1,6 +1,3 @@
-require 'open3'
-require 'tmpdir'
-
 module NewspaperWorks
   module Ingest
     class BatchIssueIngester
@@ -19,7 +16,8 @@ module NewspaperWorks
         @lccn = normalize_lccn(lccn.nil? ? lccn_from_path(path) : lccn)
         # get publication info for LCCN from authority web service:
         @publication = NewspaperWorks::Ingest::PublicationInfo.new(@lccn)
-        # issues for publication, as enumerable of PDFIssue
+        # issues for publication, as ordered enumerable object representing
+        #   issue, that (a) has metadata for issue; (b) enumerates pages.
         @issues = issue_enumerator
         @opts = opts
         configure_logger('ingest')

--- a/lib/newspaper_works/ingest/uu_article_segmented.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented.rb
@@ -1,5 +1,6 @@
 require 'newspaper_works/ingest/uu_article_segmented/has_issue_parent'
 require 'newspaper_works/ingest/uu_article_segmented/ingest_common'
+require 'newspaper_works/ingest/uu_article_segmented/issue_articles'
 require 'newspaper_works/ingest/uu_article_segmented/page_ingest'
 require 'newspaper_works/ingest/uu_article_segmented/article_ingest'
 require 'newspaper_works/ingest/uu_article_segmented/issue_ingest'

--- a/lib/newspaper_works/ingest/uu_article_segmented.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented.rb
@@ -1,0 +1,12 @@
+require 'newspaper_works/ingest/uu_article_segmented/has_issue_parent'
+require 'newspaper_works/ingest/uu_article_segmented/ingest_common'
+require 'newspaper_works/ingest/uu_article_segmented/page_ingest'
+require 'newspaper_works/ingest/uu_article_segmented/article_ingest'
+require 'newspaper_works/ingest/uu_article_segmented/issue_ingest'
+
+module NewspaperWorks
+  module Ingest
+    module UUArticleSegmented
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/uu_article_segmented/article_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/article_ingest.rb
@@ -1,0 +1,49 @@
+module NewspaperWorks
+  module Ingest
+    module UUArticleSegmented
+      class ArticleIngest
+        # Mixin XML access:
+        include NewspaperWorks::Ingest::UUArticleSegmented::IngestCommon
+        # Mixin issue parent access:
+        include NewspaperWorks::Ingest::UUArticleSegmented::HasIssueParent
+
+        attr_accessor :path, :issue
+
+        def initialize(path, issue = nil)
+          @path = path
+          @doc = nil
+          @issue = issue
+        end
+
+        # Path to article image (PDF)
+        # @return [String]
+        def image_path
+          File.expand_path(
+            xpath('//article-clipping/@image-file').first.value,
+            File.dirname(@path)
+          )
+        end
+
+        # Article text as whitespace-delimited tokens for full-text indexing.
+        #  THIS IS NOT HUMAN-READABLE, but intended as OCR-discovered text
+        #  tokens in order, including alternates.
+        def text
+          tokens = xpath(
+            './/article-element[@type="article"]//n'
+          ).to_a.map { |n| n.text }
+          line = tokens.join(' ')
+          # word-wrap long line to 80 column lines for easier debug/viewing:
+          line.scan(/\S.{0,#{80}}\S(?=\s|$)|\S+/).join("\n")
+        end
+
+        # get ordered list of pages, within issue
+        # @return [Array<NewspaperWorks::Ingest::UUArticleSegmented::PageIngest]
+        def pages
+          # page appears to be singular, but treat as plural of size 1
+          page_numbers = [xpath('//header-item[@name="page"]').first.text]
+          page_numbers.map { |n| issue.get(n) }
+        end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/uu_article_segmented/article_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/article_ingest.rb
@@ -30,7 +30,7 @@ module NewspaperWorks
         def text
           tokens = xpath(
             './/article-element[@type="article"]//n'
-          ).to_a.map { |n| n.text }
+          ).to_a.map(&:text)
           line = tokens.join(' ')
           # word-wrap long line to 80 column lines for easier debug/viewing:
           line.scan(/\S.{0,#{80}}\S(?=\s|$)|\S+/).join("\n")

--- a/lib/newspaper_works/ingest/uu_article_segmented/has_issue_parent.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/has_issue_parent.rb
@@ -1,0 +1,23 @@
+module NewspaperWorks
+  module Ingest
+    module UUArticleSegmented
+      module HasIssueParent
+        def issue_path
+          path = File.expand_path('../unit.xml', File.dirname(@path))
+          raise IOError, 'Manifest not found: #{path}' unless File.exist?(path)
+          path
+        end
+
+        # Get issue for page/article, don't construct more than once (to access
+        #   identical issue object on each call).
+        # Access to related pages is through issue, to ensure pages are
+        #   not duplicated.
+        # @return [NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest]
+        def issue
+          return @issue unless @issue.nil?
+          @issue = IssueIngest.new(issue_path, self)
+        end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/uu_article_segmented/ingest_common.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/ingest_common.rb
@@ -5,6 +5,9 @@ module NewspaperWorks
     module UUArticleSegmented
       # Mixin for common XML functionality for Issue/Page/Article ingest classes
       module IngestCommon
+        # xpath returns NodeSet for query of @doc:
+        delegate :xpath, to: :doc
+
         # @return [Nokogiri::XML::Document] XML document, namespaces removed.
         def doc
           return @doc unless @doc.nil?
@@ -13,16 +16,9 @@ module NewspaperWorks
           @doc
         end
 
-        # @param expr [String] XPath expression for query
-        # @return [Nokogiri::XML::NodeSet] NodeSet of matching
-        #   attribute or element nodes
-        def xpath(expr)
-          doc.xpath(expr)
-        end
-
         # @return [String] ISO 8601 date stamp
         def publication_date
-          Date.parse(date_stamp).to_s  # e.g. from "18-JUN-1860" to ISO8601
+          Date.parse(date_stamp).to_s # e.g. from "18-JUN-1860" to ISO8601
         end
 
         def date_stamp

--- a/lib/newspaper_works/ingest/uu_article_segmented/ingest_common.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/ingest_common.rb
@@ -16,6 +16,12 @@ module NewspaperWorks
           @doc
         end
 
+        # @return [Integer] edition number
+        def edition_number
+          v = xpath('//header-item[@name="number"]/@value').first.value
+          v.nil? ? 1 : v.to_i
+        end
+
         # @return [String] ISO 8601 date stamp
         def publication_date
           Date.parse(date_stamp).to_s # e.g. from "18-JUN-1860" to ISO8601

--- a/lib/newspaper_works/ingest/uu_article_segmented/ingest_common.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/ingest_common.rb
@@ -1,0 +1,34 @@
+require 'nokogiri'
+
+module NewspaperWorks
+  module Ingest
+    module UUArticleSegmented
+      # Mixin for common XML functionality for Issue/Page/Article ingest classes
+      module IngestCommon
+        # @return [Nokogiri::XML::Document] XML document, namespaces removed.
+        def doc
+          return @doc unless @doc.nil?
+          @doc = Nokogiri::XML(File.read(@path))
+          @doc.remove_namespaces!
+          @doc
+        end
+
+        # @param expr [String] XPath expression for query
+        # @return [Nokogiri::XML::NodeSet] NodeSet of matching
+        #   attribute or element nodes
+        def xpath(expr)
+          doc.xpath(expr)
+        end
+
+        # @return [String] ISO 8601 date stamp
+        def publication_date
+          Date.parse(date_stamp).to_s  # e.g. from "18-JUN-1860" to ISO8601
+        end
+
+        def date_stamp
+          xpath('//header-item[@name="date"]').first.text
+        end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
@@ -36,19 +36,19 @@ module NewspaperWorks
 
         # @return [Array<String>] list of paths to each page in manifest order
         def paths
-          _paths = xpath('//pages/page-ref/@href').map { |a| a.value }
+          result = xpath('//pages/page-ref/@href').map(&:value)
           # normalize to absolute paths relative to location of manifest
-          _paths.map { |p| File.expand_path(p, File.dirname(@path)) }
+          result.map { |p| File.expand_path(p, File.dirname(@path)) }
         end
 
         def article_paths
-          _paths = xpath('//articles/article-ref/@href').map { |a| a.value }
+          result = xpath('//articles/article-ref/@href').map(&:value)
           # normalize to absolute paths relative to location of manifest
-          _paths.map { |p| File.expand_path(p, File.dirname(@path)) }
+          result.map { |p| File.expand_path(p, File.dirname(@path)) }
         end
 
         def article(path)
-          NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest(
+          NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest.new(
             path, self
           )
         end

--- a/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module NewspaperWorks
   module Ingest
     module UUArticleSegmented
@@ -11,15 +13,19 @@ module NewspaperWorks
         # XML and date accessors common functionality:
         include NewspaperWorks::Ingest::UUArticleSegmented::IngestCommon
 
-        attr_accessor :path, :issue
+        delegate :lccn, to: :issue
 
-        def initialize(path)
+        attr_accessor :path, :issue, :publication
+
+        def initialize(path, publication = nil)
           @path = normalize_path(path)
           @doc = nil
           @issue = nil
           @pages = {}
           # unordered cache of article objects, keyed by path
           @articles = nil
+          # PublicationInfo, if available:
+          @publication = publication
         end
 
         # enumerable stuff: get/enumerate pages of issue
@@ -62,6 +68,14 @@ module NewspaperWorks
           path = File.expand_path('./unit.xml', path)
           raise IOError, 'Manifest not found: #{path}' unless File.exist?(path)
           path
+        end
+
+        # issue metadata accessors:
+        #   - publication_date is defined in IngestCommon mixin
+        def title
+          title_date = DateTime.iso8601(publication_date).strftime('%B %-d, %Y')
+          return [title_date] if @publication.nil?
+          ["#{publication.title}: #{title_date}"]
         end
 
         alias paths page_paths

--- a/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
@@ -1,0 +1,76 @@
+module NewspaperWorks
+  module Ingest
+    module UUArticleSegmented
+      # IssueIngest is enumerable of pages, and has accessor to list
+      #   contained articles; it is constructed with a path.
+      class IssueIngest
+        # PathEnumeration mixes in #each for Enumerable, this class provides
+        #   both #info and #paths methods to make PathEnumeration work.
+        include NewspaperWorks::Ingest::PathEnumeration
+        include Enumerable
+        # XML and date accessors common functionality:
+        include NewspaperWorks::Ingest::UUArticleSegmented::IngestCommon
+
+        attr_accessor :path, :issue
+
+        def initialize(path)
+          @path = normalize_path(path)
+          @doc = nil
+          @issue = nil
+          @pages = {}
+          @articles = nil
+        end
+
+        # enumerable stuff: get/enumerate pages of issue
+        def info(path)
+          return @pages[path] if @pages.keys.include?(path)
+          # construct each page in context of (this) issue parent:
+          @pages[path] = page_for_path(path)
+        end
+
+        def page_for_path(path)
+          NewspaperWorks::Ingest::UUArticleSegmented::PageIngest.new(
+            path, self
+          )
+        end
+
+        # @return [Array<String>] list of paths to each page in manifest order
+        def paths
+          _paths = xpath('//pages/page-ref/@href').map { |a| a.value }
+          # normalize to absolute paths relative to location of manifest
+          _paths.map { |p| File.expand_path(p, File.dirname(@path)) }
+        end
+
+        def article_paths
+          _paths = xpath('//articles/article-ref/@href').map { |a| a.value }
+          # normalize to absolute paths relative to location of manifest
+          _paths.map { |p| File.expand_path(p, File.dirname(@path)) }
+        end
+
+        def article(path)
+          NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest(
+            path, self
+          )
+        end
+
+        # @return [Array<NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest]
+        #   list of articles for issue, linked back to this issue
+        def articles
+          return @articles unless @articles.nil?
+          @articles = article_paths.map { |path| article(path) }
+        end
+
+        # return path, or if path is directory, the path to a unit.xml file
+        #   within it.
+        # @param path [String]
+        # @return [String] normalized path to issue unit.xml file.
+        def normalize_path(path)
+          return path unless File.directory?(path)
+          path = File.expand_path('./unit.xml', path)
+          raise IOError, 'Manifest not found: #{path}' unless File.exist?(path)
+          path
+        end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
@@ -53,11 +53,11 @@ module NewspaperWorks
           )
         end
 
-        # @return [Array<NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest]
+        # @return [Hash{String, NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest}]
         #   list of articles for issue, linked back to this issue
         def articles
           return @articles unless @articles.nil?
-          @articles = article_paths.map { |path| article(path) }
+          @articles = article_paths.map { |path| [path, article(path)] }.to_h
         end
 
         # return path, or if path is directory, the path to a unit.xml file

--- a/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest.rb
@@ -35,7 +35,7 @@ module NewspaperWorks
         end
 
         # @return [Array<String>] list of paths to each page in manifest order
-        def paths
+        def page_paths
           result = xpath('//pages/page-ref/@href').map(&:value)
           # normalize to absolute paths relative to location of manifest
           result.map { |p| File.expand_path(p, File.dirname(@path)) }
@@ -70,6 +70,8 @@ module NewspaperWorks
           raise IOError, 'Manifest not found: #{path}' unless File.exist?(path)
           path
         end
+
+        alias paths page_paths
       end
     end
   end

--- a/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
@@ -26,7 +26,7 @@ module NewspaperWorks
           return ["#{@issue.title.first}: Page #{page_number}"] unless @issue.nil?
           # fallback to just publication date and page number
           ["#{publication_date}: Page #{page_number}"]
-        end     
+        end
 
         # Path to page image (PDF)
         # @return [String]

--- a/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
@@ -15,6 +15,19 @@ module NewspaperWorks
           @issue = issue
         end
 
+        # @return [String] Page number string, as provided by XML:
+        def page_number
+          xpath('//header-item[@name="page"]/@value').first.text
+        end
+
+        # Title, including publication title, date when available.
+        # @return [String]
+        def title
+          return ["#{@issue.title.first}: Page #{page_number}"] unless @issue.nil?
+          # fallback to just publication date and page number
+          ["#{publication_date}: Page #{page_number}"]
+        end     
+
         # Path to page image (PDF)
         # @return [String]
         def image_path

--- a/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
@@ -30,12 +30,11 @@ module NewspaperWorks
         def text
           tokens = xpath(
             './/nodes//n'
-          ).to_a.map { |n| n.text }
+          ).to_a.map(&:text)
           line = tokens.join(' ')
           # word-wrap long line to 80 column lines for easier debug/viewing:
           line.scan(/\S.{0,#{80}}\S(?=\s|$)|\S+/).join("\n")
         end
-
       end
     end
   end

--- a/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module NewspaperWorks
   module Ingest
     module UUArticleSegmented

--- a/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
@@ -25,7 +25,8 @@ module NewspaperWorks
         def title
           return ["#{@issue.title.first}: Page #{page_number}"] unless @issue.nil?
           # fallback to just publication date and page number
-          ["#{publication_date}: Page #{page_number}"]
+          title_date = DateTime.iso8601(publication_date).strftime('%B %-d, %Y')
+          ["#{title_date}: Page #{page_number}"]
         end
 
         # Path to page image (PDF)

--- a/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
+++ b/lib/newspaper_works/ingest/uu_article_segmented/page_ingest.rb
@@ -1,0 +1,42 @@
+module NewspaperWorks
+  module Ingest
+    module UUArticleSegmented
+      class PageIngest
+        # Mixin XML access:
+        include NewspaperWorks::Ingest::UUArticleSegmented::IngestCommon
+        # Mixin issue parent access:
+        include NewspaperWorks::Ingest::UUArticleSegmented::HasIssueParent
+
+        attr_accessor :path, :issue
+
+        def initialize(path, issue = nil)
+          @path = path
+          @doc = nil
+          @issue = issue
+        end
+
+        # Path to page image (PDF)
+        # @return [String]
+        def image_path
+          File.expand_path(
+            xpath('//page/@image-file').first.value,
+            File.dirname(@path)
+          )
+        end
+
+        # Page text as whitespace-delimited tokens for full-text indexing.
+        #  THIS IS NOT HUMAN-READABLE, but intended as OCR-discovered text
+        #  tokens in order, including alternates.
+        def text
+          tokens = xpath(
+            './/nodes//n'
+          ).to_a.map { |n| n.text }
+          line = tokens.join(' ')
+          # word-wrap long line to 80 column lines for easier debug/viewing:
+          line.scan(/\S.{0,#{80}}\S(?=\s|$)|\S+/).join("\n")
+        end
+
+      end
+    end
+  end
+end

--- a/newspaper_works.gemspec
+++ b/newspaper_works.gemspec
@@ -26,7 +26,7 @@ SUMMARY
   spec.add_dependency 'blacklight_advanced_search', '6.4.1'
   spec.add_dependency 'hyrax', '>= 2.5.1', '~> 2'
   spec.add_dependency 'nokogiri'
-  spec.add_dependency 'rails', '~> 5.1'
+  spec.add_dependency 'rails', '~> 5.1.0'
   spec.add_dependency 'sass-rails', '~> 5.0'
 
   spec.add_development_dependency 'bixby'

--- a/spec/lib/newspaper_works/ingest/ingest_shared.rb
+++ b/spec/lib/newspaper_works/ingest/ingest_shared.rb
@@ -18,6 +18,9 @@ RSpec.shared_context "ingest test fixtures", shared_context: :metadata do
 
   # directory containing JP2 image fixture batch(es)
   let(:jp2_fixtures) { File.join(fixtures_path, 'jp2_batch') }
+
+  # directory containing UU article-segmented batch(es)
+  let(:article_segmented) { File.join(fixtures_path, 'article_segmented') }
 end
 
 RSpec.shared_examples 'ingest adapter IO' do

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/article_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/article_ingest_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest do
+  include_context 'ingest test fixtures'
+
+  let(:dnews) { File.join(article_segmented, 'batch_deseret_news') }
+
+  let(:article_path) { File.join(dnews, 'articles', '1.xml') }
+
+  let(:issue_path) { File.join(dnews, 'unit.xml') }
+
+  let(:article) { described_class.new(article_path) }
+
+  describe "construction and access" do
+    it "constructs adapter given path" do
+      expect(article.path).to eq article_path
+      expect(article.doc).to be_a Nokogiri::XML::Document
+    end
+
+    it "constructs adapter with optional issue context" do
+      issue = double("issue")
+      article = described_class.new(article_path, issue)
+      expect(article.issue).to be issue
+      expect(article.issue_path).to eq issue_path
+    end
+
+    it "provides date metadata for page" do
+      expect(article.publication_date).to eq '1850-06-15'
+    end
+  end
+
+  describe "image and text access" do
+    it "provides valid image path" do
+      expect(File.exist?(article.image_path)).to be true
+    end
+
+    it "provides page text tokens" do
+      text = article.text
+      expect(text).to be_a String
+      expect(text.size).to be > 0
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/articles_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/articles_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueArticles do
+  include_context 'ingest test fixtures'
+
+  let(:dnews) { File.join(article_segmented, 'batch_deseret_news') }
+
+  let(:page_path) { File.join(dnews, 'pages', 'p008_Va_071_D45_v01.xml') }
+
+  let(:article_path) { File.join(dnews, 'articles', '1.xml') }
+
+  let(:issue_path) { File.join(dnews, 'unit.xml') }
+
+  let(:issue) do
+    NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest.new(
+      issue_path
+    )
+  end
+
+  let(:articles) { described_class.new(issue_path, issue) }
+
+  let(:article_cls) do
+    NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest
+  end
+
+  describe "construction and composition" do
+    it "constructs adapter given path" do
+      expect(issue.path).to eq issue_path
+      expect(issue.doc).to be_a Nokogiri::XML::Document
+    end
+  end
+
+  describe "enumeration of articles" do
+    it "acts like a hash of page path keys, page values" do
+      expect(articles.keys).to include article_path
+      expect(articles.size).to eq 18
+      expect(articles.size).to eq articles.keys.size
+      # get value either by [] or by info method:
+      article = articles.info(article_path)
+      expect(article).to be_a article_cls
+      # [] == #info, no duplicate construction of child pages (via memoization):
+      article_again = articles[article_path]
+      expect(article_again).to be article
+      # article has reference to parent issue:
+      expect(articles.issue).to be issue
+      expect(article.issue).to be issue
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
     NewspaperWorks::Ingest::UUArticleSegmented::IssueArticles
   end
 
+  let(:lccn) { 'sn84037033' }
+
+  let(:publication) { NewspaperWorks::Ingest::PublicationInfo.new(lccn) }
+
   describe "construction and composition" do
     it "constructs adapter given path" do
       expect(issue.path).to eq issue_path
@@ -29,6 +33,13 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
 
     it "provides date metadata for issue" do
       expect(issue.publication_date).to eq '1850-06-15'
+      # issue constructed without publictation makes due with what it has:
+      expect(issue.title).to contain_exactly "June 15, 1850"
+      # when issue is constructed with publication, embed publication title:
+      issue = described_class.new(issue_path, publication)
+      expect(issue.title).to contain_exactly "Deseret news: June 15, 1850"
+      # edition number
+      expect(issue.edition_number).to eq 1
     end
   end
 

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
+  include_context 'ingest test fixtures'
+
+  let(:dnews) { File.join(article_segmented, 'batch_deseret_news') }
+
+  let(:page_path) { File.join(dnews, 'pages', 'p008_Va_071_D45_v01.xml') }
+
+  let(:issue_path) { File.join(dnews, 'unit.xml') }
+
+  let(:issue) { described_class.new(issue_path) }
+
+  let(:page_cls) { NewspaperWorks::Ingest::UUArticleSegmented::PageIngest }
+
+  let(:article_cls) {
+    NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest
+  }
+
+  describe "construction and composition" do
+    it "constructs adapter given path" do
+      expect(issue.path).to eq issue_path
+      expect(issue.doc).to be_a Nokogiri::XML::Document
+    end
+
+    it "provides date metadata for issue" do
+      expect(issue.publication_date).to eq '1850-06-15'
+    end
+  end
+
+  describe "enumeration of pages and articles" do
+    it "acts like a hash of page path keys, page values" do
+      expect(issue.keys).to include page_path
+      expect(issue.size).to eq 8
+      expect(issue.size).to eq issue.keys.size
+      # get value either by [] or by info method:
+      page = issue.info(page_path)
+      expect(page).to be_a page_cls
+      # [] == #info, no duplicate construction of child pages (via memoization):
+      page_again = issue[page_path]
+      expect(page_again).to be page
+    end
+
+    it "provides accessor to list of articles" do
+      articles = issue.articles
+      expect(articles.size).to eq 18
+      article = articles[0]
+      expect(article).to be_a article_cls
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
 
   let(:page_cls) { NewspaperWorks::Ingest::UUArticleSegmented::PageIngest }
 
-  let(:article_cls) {
+  let(:article_cls) do
     NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest
-  }
+  end
 
   describe "construction and composition" do
     it "constructs adapter given path" do
@@ -41,10 +41,10 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
       expect(page_again).to be page
     end
 
-    it "provides accessor to list of articles" do
+    it "provides accessor to hash of articles" do
       articles = issue.articles
       expect(articles.size).to eq 18
-      article = articles[0]
+      article = articles.values[0]
       expect(article).to be_a article_cls
     end
   end

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/issue_ingest_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
     NewspaperWorks::Ingest::UUArticleSegmented::ArticleIngest
   end
 
+  let(:articles_cls) do
+    NewspaperWorks::Ingest::UUArticleSegmented::IssueArticles
+  end
+
   describe "construction and composition" do
     it "constructs adapter given path" do
       expect(issue.path).to eq issue_path
@@ -43,6 +47,7 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::IssueIngest do
 
     it "provides accessor to hash of articles" do
       articles = issue.articles
+      expect(articles).to be_a articles_cls
       expect(articles.size).to eq 18
       article = articles.values[0]
       expect(article).to be_a article_cls

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/page_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/page_ingest_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'date'
 
 RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::PageIngest do
   include_context 'ingest test fixtures'
@@ -28,7 +29,8 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::PageIngest do
       expect(page.page_number).to eq '8'
       expect(page.publication_date).to eq '1850-06-15'
       # title without issue context contains date and page_number:
-      expected_title = "#{page.publication_date}: Page #{page.page_number}"
+      date = DateTime.iso8601(page.publication_date).strftime('%B %-d, %Y')
+      expected_title = "#{date}: Page #{page.page_number}"
       expect(page.title).to contain_exactly expected_title
     end
   end

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/page_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/page_ingest_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::PageIngest do
     end
 
     it "provides date metadata for page" do
+      expect(page.page_number).to eq '8'
       expect(page.publication_date).to eq '1850-06-15'
+      # title without issue context contains date and page_number:
+      expected_title = "#{page.publication_date}: Page #{page.page_number}"
+      expect(page.title).to contain_exactly expected_title
     end
   end
 

--- a/spec/lib/newspaper_works/ingest/uu_article_segmented/page_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/uu_article_segmented/page_ingest_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe NewspaperWorks::Ingest::UUArticleSegmented::PageIngest do
+  include_context 'ingest test fixtures'
+
+  let(:dnews) { File.join(article_segmented, 'batch_deseret_news') }
+
+  let(:page_path) { File.join(dnews, 'pages', 'p008_Va_071_D45_v01.xml') }
+
+  let(:issue_path) { File.join(dnews, 'unit.xml') }
+
+  let(:page) { described_class.new(page_path) }
+
+  describe "construction and composition" do
+    it "constructs adapter given path" do
+      expect(page.path).to eq page_path
+      expect(page.doc).to be_a Nokogiri::XML::Document
+    end
+
+    it "constructs adapter with optional issue context" do
+      issue = double("issue")
+      page = described_class.new(page_path, issue)
+      expect(page.issue).to be issue
+      expect(page.issue_path).to eq issue_path
+    end
+
+    it "provides date metadata for page" do
+      expect(page.publication_date).to eq '1850-06-15'
+    end
+  end
+
+  describe "image and text access" do
+    it "provides valid image path" do
+      expect(File.exist?(page.image_path)).to be true
+    end
+
+    it "provides page text tokens" do
+      text = page.text
+      expect(text).to be_a String
+      expect(text.size).to be > 0
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,15 @@ require 'rspec/active_model/mocks'
 require 'selenium-webdriver'
 require 'webdrivers'
 
+# monkey patch Hyrax::VirusScanner#null_scanner to be quiet:
+module Hyrax
+  class VirusScanner
+    def null_scanner
+      false # no warning output, just correct return value
+    end
+  end
+end
+
 # @note In January 2018, TravisCI disabled Chrome sandboxing in its Linux
 #       container build environments to mitigate Meltdown/Spectre
 #       vulnerabilities, at which point Hyrax could no longer use the
@@ -115,8 +124,12 @@ RSpec.configure do |config|
 
   config.include EngineRoutes, type: :controller
 
-  # ensure Hyrax has active sipity workflow for default admin set:
+  # start with clean repository, active sipity workflow for default admin set:
   config.before(:suite) do
+    # completely clean repository before suite:
+    require 'active_fedora/cleaner'
+    ActiveFedora::Cleaner.clean!
+
     begin
       # ensure permission template actually exists in RDBMS:
       id = 'admin_set/default'


### PR DESCRIPTION
In our 2018-12-06 knowledge transfer meeting, we discussed the possibility of using a PR to document work done on the `article-ingest` branch, without the intent of actually merging the branch now.

At present, this branch is stuck in limbo, largely because we don’t have sufficient material to enumerate over, re: sample materials containing *mulitple issues*.

At this time, what’s in `lib/newspaper_works/ingest/uu_article_segmented` is interface-compatible (same methods) with what the methods in `NewspaperWorks::Ingest::BatchIngestHelper` mixin consume, work with, but there is no imperative ingest class.

Writing a `NewspaperWorks::Ingest::UUArticleSegmented::BatchIssueIngester` class — which could be done provided sufficient sample fixtures — would look much like the `NewspaperWorks::Ingest::BatchIssueIngester` class that handles PDF, JP2/TIFF (it would mix in both `NewspaperWorks::Ingest::BatchIngestHelper`, `NewspaperWorks::Ingest::FromCommand`).  This ingest would also need to use `NewspaperWorks::ImageTool` to convert the PDFs to TIFF on ingest (_to avoid some peculiarities in how `Hyrax::FileSetDerivativeService` deals with PDF primary files.

*Note:* there is a minor refactoring in this branch of `NewspaperWorks::Ingest::BatchIssueIngester` and `NewspaperWorks::Ingest::BatchIngestHelper` at these two commits: 1074d8499f2a846344392065fcb00ed96aaf54be and https://github.com/samvera-labs/newspaper_works/commit/6ed9fcf192c3d4f8d665b9de4ca2fcf74d22d011 — these two commits might be worth cherry-picking independently to master, as they make re-use of much of that is in `BatchIngestHelper` easy for new ingests (including those written in other gems).
