### PR TITLE
Refactoring as part of code read

### DIFF
--- a/lib/newspaper_works/ingest/batch_ingest_helper.rb
+++ b/lib/newspaper_works/ingest/batch_ingest_helper.rb
@@ -4,10 +4,12 @@ module NewspaperWorks
   module Ingest
     # mixin module for common batch ingest steps
     module BatchIngestHelper
+      MEDIA_PDF = 'pdf'
+      MEDIA_IMAGE = 'image'
       def detect_media(path)
-        result = 'pdf' # default
+        result = MEDIA_PDF # default
         Find.find(path) do |p|
-          result = 'image' if p.end_with?('jp2') || /TIF[F]?$/i.match(p)
+          result = MEDIA_IMAGE if p.end_with?('jp2') || /TIF[F]?$/i.match(p)
         end
         result
       end


### PR DESCRIPTION
These are minor refactors that I performed while reading the `NewspaperWorks::Ingest::BatchIngestHelper`.  A major rework was "privatizing" several methods, which are used only within the `#ingest` method.  This helps clarify what is the interface for the object.

There are a few outstanding questions regarding using `.create` instead of `.new`; but those are not things I'm looking to adjust in this read through.