### PR TITLE
Extracting convenience method

### DIFF
--- a/app/indexers/concerns/newspaper_works/indexes_full_text.rb
+++ b/app/indexers/concerns/newspaper_works/indexes_full_text.rb
@@ -8,7 +8,7 @@ module NewspaperWorks
     # @param work [Newspaper*] an instance of a NewspaperWorks model
     # @param solr_doc [Hash] the hash of field data to be pushed to Solr
     def index_full_text(work, solr_doc)
-      text = NewspaperWorks::Data::WorkDerivatives.new(work).data('txt')
+      text = NewspaperWorks::Data::WorkDerivatives.data(from: work, of_type: 'txt')
       text = text.gsub(/\n/, ' ').squeeze(' ')
       solr_doc['all_text_timv'] = text
       solr_doc['all_text_tsimv'] = text

--- a/app/models/concerns/newspaper_works/blacklight_iiif_search/annotation_behavior.rb
+++ b/app/models/concerns/newspaper_works/blacklight_iiif_search/annotation_behavior.rb
@@ -44,7 +44,7 @@ module NewspaperWorks
       # return the JSON word-coordinates file contents
       # @return [JSON]
       def fetch_and_parse_coords
-        coords = NewspaperWorks::Data::WorkDerivatives.new(file_set_id).data('json')
+        coords = NewspaperWorks::Data::WorkDerivatives.data(from: file_set_id, of_type: 'json')
         return nil if coords.blank?
         begin
           JSON.parse(coords)

--- a/lib/newspaper_works/data/work_derivatives.rb
+++ b/lib/newspaper_works/data/work_derivatives.rb
@@ -37,6 +37,14 @@ module NewspaperWorks
         attr_accessor :remap_names
       end
 
+      # @param from [Object] the work from which we'll extract the given type of data.
+      # @param of_type [String] the type of data we want extracted from the work (e.g. "txt", "json")
+      #
+      # @return [String]
+      def self.data(from:, of_type:)
+        new(from).data(of_type)
+      end
+
       # alternate constructor spelling:
       def self.of(work, fileset = nil, parent = nil)
         new(work, fileset, parent)
@@ -208,6 +216,7 @@ module NewspaperWorks
       # @param name [String] optional destination name, usually file extension
       # @return [TrueClass, FalseClass] boolean
       def exist?(name)
+        # TODO: It is unclear where the #keys and and #[] methods are coming from.  There's @paths.keys referenced in this code.
         keys.include?(name) && File.exist?(self[name])
       end
 


### PR DESCRIPTION
As part of my read through of this gem, I'm looking at noop refactors that can help expose the expected public interface of the class interactions.

This refactor follows on the principle of the Law of Demeter; namely try to avoid method chains.  Method chains aren't intrinsicly bad, but there's also a command/query separation to consider.

This change helps those that interact with
`NewspaperWorks::Data::WorkDerivatives` not need to know about the implementation details of that class.  Instead exposing convenience methods for that class.